### PR TITLE
Make this work again

### DIFF
--- a/scripts/page.js
+++ b/scripts/page.js
@@ -1,57 +1,8 @@
-var INTERVAL_PERIOD = 200; // ms
-var getSponsoredPosts = function() {
-  var $sponsoredTags = $('ul.uiStreamHomepage .uiStreamAdditionalLogging');
-  // Only return sponsored posts that have not yet been flagged
-  return $sponsoredTags.parents('li.uiStreamStory:not(.sponsoredPost)');
+var INTERVAL_PERIOD = 500; // ms
+
+var hideSuggestedPosts = function() {
+  $("span:contains('Suggested Post')").parents('.userContentWrapper').html("<div class='hiddenPost'>&nbsp;</div>");
+  $("span:contains('Sponsored')").parents('.userContentWrapper').html("<div class='hiddenPost'>&nbsp;</div>");
 };
-var announceSponsoredPosts = function(callback) {
-  var children;
-  window.setInterval(function() {
-    $posts = getSponsoredPosts();
-    if ($posts.length) {
-      callback($posts);
-    }
-  }, INTERVAL_PERIOD);
-};
-var injectSponsoredMention = function($post) {
-  // Flag sponsored posts so they won't be matched by future searches
-  $post.addClass('sponsoredPost');
-  // Inject post mention bar with show button that reveals the original post
-  $post.prepend(
-    '<div class="sponsoredMention">' +
-      '<a href="#" class="toggleMention">' +
-        '<span class="show">Show ↓</span>' +
-        '<span class="hide">Hide ↑</span>' +
-      '</a> ' +
-      'sponsored post' +
-    '</div>'
-  );
-  var $sponsoredMention = $post.find('.sponsoredMention');
-  $sponsoredMention.find('.toggleMention').click(function(e) {
-    e.preventDefault();
-    $post.toggleClass('revealedSponsoredPost');
-  });
-  // Add reference to sponsored subject
-  var subjectAnchor = $post.find('.actorName a:first');
-  if (!subjectAnchor.length) {
-    subjectAnchor = $post.find('.uiAttachmentTitle a:first');
-  }
-  if (subjectAnchor.length) {
-    $sponsoredMention.append(' from ');
-    subjectAnchor.clone().appendTo($sponsoredMention);
-  }
-};
-$.fn.hideSponsoredPost = function() {
-  $(this).each(function(i, post) {
-    injectSponsoredMention($(this));
-  });
-};
-var totalCount = 0;
-// Since there wasn't any obvious way to listen to news feed changes, we had
-// to resort to a basic interval for checking whenever new items are loaded
-// within the feed
-announceSponsoredPosts(function($posts) {
-  totalCount += $posts.length;
-  console.log('Hid ' + $posts.length + ' more sponsored post. ' + totalCount + ' posts hidden so far.');
-  $posts.hideSponsoredPost();
-});
+
+window.setInterval(hideSuggestedPosts, INTERVAL_PERIOD);

--- a/styles/page.css
+++ b/styles/page.css
@@ -1,31 +1,5 @@
-/* hidden */
-.sponsoredPost .sponsoredMention {
-  margin: 18px 0;
-  opacity: 0.8;
-}
-.sponsoredPost .sponsoredMention a {
-  font-weight: bold;
-}
-.sponsoredPost .sponsoredMention .toggleMention .show {
-  display: inline;
-}
-.sponsoredPost .sponsoredMention .toggleMention .hide {
-  display: none;
-}
-.sponsoredPost .storyContent {
-  display: none;
-}
-/* revealed */
-.revealedSponsoredPost .sponsoredMention {
-  margin: 18px 0 0 0;
-  opacity: 1;
-}
-.revealedSponsoredPost .sponsoredMention .toggleMention .show {
-  display: none;
-}
-.revealedSponsoredPost .sponsoredMention .toggleMention .hide {
-  display: inline;
-}
-.revealedSponsoredPost .storyContent {
-  display: block;
+.hiddenPost {
+  width: 100%;
+  height: 20px;
+  background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAKklEQVQYV2NkgIKIuoUN+q4hDIwgPoxTacvdwIjMAUkyth/+2gCSgakEAOr9ELt2ymgLAAAAAElFTkSuQmCC)
 }


### PR DESCRIPTION
Simplify the script so it just strips suggested or sponsored posts from
the feed and replace them with a subtle gradient div. They will now look like,

![image](https://user-images.githubusercontent.com/601660/32679126-1260fbae-c61a-11e7-8066-48a94a710ff1.png)

@skidding Please have a look. I made significant changes to how it works so this could become a more maintainable spam filter extension.